### PR TITLE
Fix repo naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/gateio/GateApi.git"
+      "url": "https://github.com/gateio/gateapi-php.git"
     }
   ],
   "require": {
-    "gateio/GateApi": "*@dev"
+    "gateio/gateapi": "*@dev"
   }
 }
 ```


### PR DESCRIPTION
This fix solve the issue i get when i try to install the package based on the existing documentation.